### PR TITLE
Remove `quote` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.55"
+version = "2.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,6 @@ version = 3
 name = "coffee_break"
 version = "1.0.0"
 dependencies = [
- "quote",
  "syn",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-quote = "1.0.10"
 syn = "2.0.53"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,8 @@ categories = ["development-tools", "development-tools::build-utils"]
 [lib]
 proc-macro = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-syn = "2.0.53"
+syn = { version = "2.0.53", default-features = false, features = ["proc-macro", "parsing"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools", "development-tools::build-utils"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "2.0.53", default-features = false, features = ["proc-macro", "parsing"] }
+syn = { version = "2.0.57", default-features = false, features = ["proc-macro", "parsing"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!("../README.md")]
 
 use proc_macro::TokenStream;
-use quote::quote;
 use syn::{parse::Parse, Error};
 
 /// Take a break when compiling.
@@ -26,7 +25,9 @@ pub fn coffee_break(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as CoffeeBreak);
 
     std::thread::sleep(std::time::Duration::from_secs(input.seconds));
-    quote! {()}.into()
+
+    // Return empty stream.
+    TokenStream::new()
 }
 
 struct CoffeeBreak {


### PR DESCRIPTION
`quote`'s only usage is returning a unit `()` statement. This behavior can be accomplished by calling [`TokenStream::new`], which returns an empty token stream.

[`TokenStream::new`]: https://doc.rust-lang.org/stable/proc_macro/struct.TokenStream.html#method.new

This does change the generated output, but it still accomplishes the same result.

```rust
// stretch_your_legs.rs

// Before
fn main() {
    ();
}

// After
fn main() {

}
```

Unfortunately it only removes `quote` as an immediate dependency. `syn` still dependends on `quote`, even when I reduced the enabled features. I'm pretty sure this is a bug ([on this line](https://github.com/dtolnay/syn/blob/c7f734d8c1c288ea5fc48391a419c23ade441cac/Cargo.toml#L34)), but there is nothing that can be done in this PR.