### PR TITLE
Add features `ra-friendly` and `check-friendly` to make it friendlier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ categories = ["development-tools", "development-tools::build-utils"]
 [lib]
 proc-macro = true
 
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+ra-friendly = []
+check-friendly = []
+
 [dependencies]
 syn = { version = "2.0.57", default-features = false, features = ["proc-macro", "parsing"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+default = ["ra-friendly", "check-friendly"]
 ra-friendly = []
 check-friendly = []
 


### PR DESCRIPTION
I love to take breaks, but not each time I ask `rust-analyzer` to complete something or when I run `cargo check/clippy` to find errors, so I added two optional features to make it friendlier to them.

- `ra-friendly` for `rust-analyzer`
- `check-friendly` for `cargo check/clippy`

[EDIT] I took two coffee breaks during this PR :coffee: 